### PR TITLE
Fix Issue 38804

### DIFF
--- a/packages/querygrid/README.md
+++ b/packages/querygrid/README.md
@@ -4,6 +4,10 @@ Query Grid for LabKey schema/query data views
 
 ## Release Notes ##
 
+### version 0.22.4
+*Released*: 14 November 2019
+* Fix Issue 38804
+
 ### version 0.22.3
 *Released*: 13 November 2019
 * Add headerURL to MenuSectionConfig

--- a/packages/querygrid/package.json
+++ b/packages/querygrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glass/querygrid",
-  "version": "0.22.4-fb-issue-38804.1",
+  "version": "0.22.4",
   "description": "Query Grid for LabKey schema/query data views",
   "main": "dist/querygrid.cjs.js",
   "module": "dist/querygrid.es.js",

--- a/packages/querygrid/package.json
+++ b/packages/querygrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glass/querygrid",
-  "version": "0.22.3",
+  "version": "0.22.4-fb-issue-38804.1",
   "description": "Query Grid for LabKey schema/query data views",
   "main": "dist/querygrid.cjs.js",
   "module": "dist/querygrid.es.js",

--- a/packages/querygrid/src/components/GridLoader.tsx
+++ b/packages/querygrid/src/components/GridLoader.tsx
@@ -27,7 +27,7 @@ class GridLoader implements IGridLoader {
             return selectRows({
                 schemaName: model.schema,
                 queryName: model.query,
-                // viewName: model.view,
+                viewName: model.view,
                 filterArray: model.getFilters().toJS(),
                 sort: model.getSorts(),
                 columns: model.getRequestColumnsString(),

--- a/packages/querygrid/src/components/report-list/ReportList.spec.tsx
+++ b/packages/querygrid/src/components/report-list/ReportList.spec.tsx
@@ -44,7 +44,7 @@ const urlMapper = (report) => {
 };
 
 describe('<ReportList />', () => {
-    test('flattenApiResponse works with valid data', () => {
+    test('flattenBrowseDataTreeResponse works with valid data', () => {
         flattenBrowseDataTreeResponse(exampleData, urlMapper);
     });
 


### PR DESCRIPTION
For some reason GridLoader was *never* using the view name from the QueryGridModel. The necessary line of code was commented out.